### PR TITLE
Extend the generated oscal with all the .csv fields

### DIFF
--- a/csv_to_oscal.py
+++ b/csv_to_oscal.py
@@ -86,7 +86,7 @@ def create_catalog(controls: list[CloudNativeControlCsvRow]) -> Catalog:
 
 def write_catalog(catalog: Catalog, output: PathLike) -> None:
     with open(output, "w") as fh:
-        fh.write(catalog.json())
+        fh.write(catalog.json(exclude_unset=True, indent=4))
 
 
 def get_args_config() -> dict:


### PR DESCRIPTION
Map .csv fields to props in the generated oscal.

Some of the content needs to be sanitised (remove leading/trailing whitespace, etc.) to pass the trestle field constraints. I chose to do this programmatically rather than modifying the source  in the .csv file.